### PR TITLE
First draft of the output of the discard keys design team

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1101,6 +1101,7 @@ decrypt 1-RTT packets from the client.
 Even though 1-RTT keys are available to a server after receiving the first
 handshake messages from a client, it is missing assurances on the state of the
 client:
+
 - The client is not authenticated (unless the server has chosen to use a
 pre-shared key and validated the client's pre-shared key binder (see
 Section 4.2.11 of [TLS13]).

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -373,12 +373,12 @@ Additional functions might be needed to configure TLS.
 
 In this document, the TLS handshake is considered complete when the TLS stack
 has reported that the handshake is complete.  This happens when the TLS stack
-has verified the peer's Finished message.  Verifying the peer's Finished
-provides endpoints with an assurance that previous handshake messages have not
-been modified.  Note that the handshake does not complete on both endpoints
-simultaneously, therefore any requirements placed on endpoints based on the
-completion of the handshake are specific to the handshake being complete from
-the perspective of the endpoint in question.
+has both sent a Finished message and verified the peer's Finished message.
+Verifying the peer's Finished provides endpoints with an assurance that
+previous handshake messages have not been modified.  Note that the handshake
+does not complete on both endpoints simultaneously, therefore any requirements
+placed on endpoints based on the completion of the handshake are specific to
+the handshake being complete from the perspective of the endpoint in question.
 
 
 ### Handshake Confirmed {#handshake-confirmed}
@@ -707,10 +707,12 @@ and ignoring any outstanding Initial packets.
 
 An endpoint MUST NOT discard its handshake keys until the TLS handshake is
 confirmed ({{handshake-confirmed}}).  An endpoint SHOULD discard its handshake
-keys as soon as it has confirmed the handshake.  Endpoints SHOULD repeatedly
-send ACK-eliciting frames encrypted with 1-RTT keys as soon as they have
-installed those send keys and until they receive an acknowledgment for one of
-them.
+keys as soon as it has confirmed the handshake.  Most applications protocols
+will send data after the handshake, ensuring the peer can discard their
+handshake keys promptly.  Applications protocols that do not MAY send
+ACK-eliciting frames encrypted with 1-RTT keys as soon as they have installed
+those send keys and until they receive an acknowledgment for one of them,
+ensuring the peer can discard their handshake keys.
 
 
 ### Discarding 0-RTT Keys

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -697,7 +697,7 @@ highest value of the Largest Acknowledged field in any received 1-RTT ACK
 frame: once the latter is higher than the former, the handshake is confirmed.
 
 An endpoint MUST NOT discard its handshake keys until the TLS handshake is
-confirmed from its perspective.  An endpoint MAY discard its handshake keys
+confirmed from its perspective.  An endpoint SHOULD discard its handshake keys
 as soon as it has confirmed the handshake.  Endpoints SHOULD repeatedly send
 ACK-eliciting frames encrypted with 1-RTT keys as soon as they have installed
 those send keys and until they receive an acknowledgment for one of them.


### PR DESCRIPTION
THIS IS AN EARLY DRAFT OF THE OUTPUT OF THE DESIGN TEAM, WE HAVE NOT YET CONFIRMED CONSENSUS.

Hi design team members, please review this PR and let me know if it matches the consensus we reached over the past weeks. This PR is against my personal repository, I'll make one against the official WG repo after incorporating your feedback.

Description that will be sent to the WG:

============================================

This PR is the output of the discard keys design team, and has reached consensus amongst design team members. It describes methods for discarding QUIC packet protection keys, and adds normative text to ensure that this mechanism is not vulnerable to deadlocks. This PR also formalizes the concept of handshake complete and handshake confirmed. Finally, this PR also moved some text around to avoid repetitions.
